### PR TITLE
Add OpenVox 9 / Ruby 4.0 preview and drop the puppet gem

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,17 +1,9 @@
 ---
 fixtures:
   repositories:
-    iptables:
-      repo: https://github.com/simp/pupmod-simp-iptables.git
-      ref: 6.2.2
-    simplib:
-      repo: https://github.com/simp/pupmod-simp-simplib.git
-      ref: 3.15.3
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib.git
-      ref: 4.13.1
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
-    disa_stig-el7-baseline:
-      repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
-      branch: master
-      target: spec/fixtures/inspec_deps/inspec_profiles/profiles
+    augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
+    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld.git
+    iptables: https://github.com/simp/pupmod-simp-iptables.git
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -15,5 +15,3 @@ fixtures:
       repo: https://github.com/simp/inspec-profile-disa_stig-el7.git
       branch: master
       target: spec/fixtures/inspec_deps/inspec_profiles/profiles
-  symlinks:
-    dummy: "#{source_dir}"

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -26,19 +26,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-env:
-  PUPPET_VERSION: '~> 7'
-
 jobs:
   puppet-syntax:
     name: 'Puppet Syntax'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
       - name: "Install Ruby 2.7"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7.8
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -46,11 +43,11 @@ jobs:
     name: 'Puppet Style'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
       - name: "Install Ruby 2.7"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 2.7
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -60,11 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
       - name: "Install Ruby 2.7"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 2.7
           bundler-cache: true
       - run: |
           bundle show
@@ -74,11 +71,11 @@ jobs:
     name: 'File checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
       - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -87,11 +84,11 @@ jobs:
     name: 'RELENG checks'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
       - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 2.7
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -99,7 +96,7 @@ jobs:
           bundle exec rake pkg:compare_latest_tag[,true]
           bundle exec rake pkg:create_tag_changelog
       - name: 'Test-build the Puppet module'
-        run: 'bundle exec pdk build --force'
+        run: 'bundle exec rake pupmod:build'
 
   spec-tests:
     name: 'Puppet Spec'
@@ -112,15 +109,25 @@ jobs:
             puppet_version: '~> 7.0'
             ruby_version: '2.7'
             experimental: false
-          - label: 'Puppet 8.x'
+          - label: 'OpenVox 8.x (Ruby 3.2)'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'
+            experimental: false
+          - label: 'OpenVox 8.x (Ruby 3.4)'
+            puppet_version: '~> 8.0'
+            ruby_version: '3.4'
+            experimental: false
+          # OpenVox 9 is unreleased; preview the future Ruby 4.0 / OpenVox 9
+          # combo by running the OpenVox 8 gem on Ruby 4.0.
+          - label: 'OpenVox 9.x preview (Ruby 4.0, OpenVox 8 gem)'
+            puppet_version: '~> 8.0'
+            ruby_version: '4.0'
             experimental: false
       fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
       - name: 'Install Ruby ${{matrix.puppet.ruby_version}}'
         uses: ruby/setup-ruby@v1
         with:
@@ -138,5 +145,3 @@ jobs:
 #        env:
 #          GITHUB_CONTEXT: ${{ toJson(github) }}
 #        run: echo "$GITHUB_CONTEXT"
-#
-#         bundle exec rake beaker:suites[default,${{ matrix.node }}]

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "Install Ruby 2.7"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -47,7 +47,7 @@ jobs:
       - name: "Install Ruby 2.7"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -61,7 +61,7 @@ jobs:
       - name: "Install Ruby 2.7"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: |
           bundle show
@@ -75,7 +75,7 @@ jobs:
       - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -88,7 +88,7 @@ jobs:
       - name: 'Install Ruby 2.7'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2.11
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -105,10 +105,6 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
           - label: 'OpenVox 8.x (Ruby 3.2)'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -49,20 +49,20 @@ jobs:
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
       - run: bundle exec rake pkg:create_tag_changelog
       - run: bundle exec rake metadata_lint
       - name: "Test that Puppet module can build"
-        run: "bundle exec pdk build --force"
+        run: "bundle exec rake pupmod:build"
 
 
   create-github-release:
@@ -75,7 +75,7 @@ jobs:
       tag: ${{ steps.tag-check.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -135,12 +135,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - el8
-          - el9
-          - el10
+          - centos7
+          - centos8
     steps:
       - name: Trigger RPM release workflow (${{ matrix.os }})
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           TARGET_TAG: ${{ needs.create-github-release.outputs.tag }}
@@ -175,16 +174,16 @@ jobs:
       FORGE_API_URL: https://forgeapi.puppet.com/v3/releases
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: Build Puppet module (PDK)
-        run: bundle exec pdk build --force
+        run: bundle exec rake pupmod:build
       - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           curl -X POST --silent --show-error --fail \

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,9 @@ dist
 /pkg
 # Read everything in fixtures
 /spec/fixtures/*
-# Un-ignore hieradata
+# Un-ignore hieradata. The directory itself must be re-included first, otherwise
+# `/spec/fixtures/*` above excludes it and git cannot re-include files within it.
+!/spec/fixtures/hieradata/
 !/spec/fixtures/hieradata/*
 # Except this one, which is auto-generated
 /spec/fixtures/hieradata/hiera.yaml

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -13,3 +13,4 @@
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check
+--no-strict_indent-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Aug 11 2026 Steven Pritchard <steve@sicura.us> - 0.6.0
+- Require OpenVox 8 and update to currently supported operating systems
+- Update dependencies and issues URL in metadata.json
+- Clean up .fixtures.yml (drop version pins, compliance_markup, and the
+  DISA STIG InSpec profile)
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 0.5.4
 - Documented parameters, added data types, and resolved puppet-lint offenses
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 0.5.4
+- Documented parameters, added data types, and resolved puppet-lint offenses
+
 * Wed Jan 05 2022 First Last <email@domain.com> - 0.5.3
 - A thing that changed
 - Another thing that changed

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ group :syntax do
 end
 
 group :test do
-  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
   openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
   gem 'hiera-puppet-helper'
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,11 @@ group :test do
   gem 'hiera-puppet-helper'
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem 'openvox', openvox_version
+  # Pin openfact to facterdb's newest shipped fact set: with a newer
+  # openfact, simp-rspec-puppet-facts' fact-fallback path leaks memory
+  # catastrophically (OOM-kills CI runners and dev machines) even on this
+  # trivial module's spec suite
+  gem 'openfact', ENV.fetch('OPENFACT_VERSION', '~> 5.6.0')
   gem 'openvox-strings'
   gem 'rake'
   gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :test do
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
+  gem 'observer', require: false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,33 +6,30 @@
 # ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS', 'https://rubygems.org').split(%r{[, ]+})
 
-ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
-
 gem_sources.each { |gem_source| source gem_source }
 
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.68.0'
+  # rubocop, rubocop-rake, and rubocop-rspec are pulled in and version-pinned by
+  # voxpupuli-test (via simp-rake-helpers); pinning them here conflicts with its
+  # constraints. rubocop-performance is not a voxpupuli-test dependency, so it
+  # stays explicit.
   gem 'rubocop-performance', '~> 1.23.0'
-  gem 'rubocop-rake', '~> 0.6.0'
-  gem 'rubocop-rspec', '~> 3.2.0'
 end
 
 group :test do
   puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
-  major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
+  openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
   gem 'hiera-puppet-helper'
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  gem 'puppet', puppet_version
-  gem 'puppetlabs_spec_helper'
-  gem 'puppet-strings'
+  gem 'openvox', openvox_version
+  gem 'openvox-strings'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-puppet'
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '>= 5.23.0')
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 3.7')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
 end
 
 group :development do
@@ -45,7 +42,7 @@ group :system_tests do
   gem 'bcrypt_pbkdf'
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 2.0.0')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 3.1')
 end
 
 # Evaluate extra gemfiles if they exist

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -42,6 +42,8 @@ The following parameters are available in the `dummy` class:
 
 * [`service_name`](#-dummy--service_name)
 * [`package_name`](#-dummy--package_name)
+* [`package_ensure`](#-dummy--package_ensure)
+* [`tcp_listen_port`](#-dummy--tcp_listen_port)
 * [`trusted_nets`](#-dummy--trusted_nets)
 * [`auditing`](#-dummy--auditing)
 * [`firewall`](#-dummy--firewall)
@@ -50,8 +52,6 @@ The following parameters are available in the `dummy` class:
 * [`selinux`](#-dummy--selinux)
 * [`tcpwrappers`](#-dummy--tcpwrappers)
 * [`foo`](#-dummy--foo)
-* [`package_ensure`](#-dummy--package_ensure)
-* [`tcp_listen_port`](#-dummy--tcp_listen_port)
 * [`bar`](#-dummy--bar)
 
 ##### <a name="-dummy--service_name"></a>`service_name`
@@ -70,13 +70,29 @@ The name of the dummy package
 
 Default value: `'dummy'`
 
+##### <a name="-dummy--package_ensure"></a>`package_ensure`
+
+Data type: `String[1]`
+
+The ensure status of the dummy package
+
+Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
+
+##### <a name="-dummy--tcp_listen_port"></a>`tcp_listen_port`
+
+Data type: `Simplib::Port`
+
+The TCP port on which the dummy service listens
+
+Default value: `9999`
+
 ##### <a name="-dummy--trusted_nets"></a>`trusted_nets`
 
 Data type: `Simplib::Netlist`
 
 A whitelist of subnets (in CIDR notation) permitted access
 
-Default value: `simplib::lookup('simp_options::trusted_nets', {'default_value' => ['127.0.0.1/32'] })`
+Default value: `simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1/32'] })`
 
 ##### <a name="-dummy--auditing"></a>`auditing`
 
@@ -134,27 +150,11 @@ A new API thingamie
 
 Default value: `true`
 
-##### <a name="-dummy--package_ensure"></a>`package_ensure`
-
-Data type: `String[1]`
-
-
-
-Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
-
-##### <a name="-dummy--tcp_listen_port"></a>`tcp_listen_port`
-
-Data type: `Simplib::Port`
-
-
-
-Default value: `9999`
-
 ##### <a name="-dummy--bar"></a>`bar`
 
 Data type: `Boolean`
 
-
+Another new API thingamie
 
 Default value: `true`
 

--- a/manifests/config/auditing.pp
+++ b/manifests/config/auditing.pp
@@ -6,7 +6,6 @@ class dummy::config::auditing {
   # FIXME: ensure your module's auditing settings are defined here.
   $msg = "FIXME: define the ${module_name} module's auditing settings."
 
-  notify{ 'FIXME: auditing': message => $msg } # FIXME: remove this and add logic
+  notify { 'FIXME: auditing': message => $msg } # FIXME: remove this and add logic
   err( $msg )                                  # FIXME: remove this and add logic
-
 }

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -5,7 +5,7 @@ class dummy::config::firewall {
 
   # FIXME: ensure your module's firewall settings are defined here.
   iptables::listen::tcp_stateful { 'allow_dummy_tcp_connections':
-    trusted_nets => $::dummy::trusted_nets,
-    dports       => $::dummy::tcp_listen_port
+    trusted_nets => $dummy::trusted_nets,
+    dports       => $dummy::tcp_listen_port
   }
 }

--- a/manifests/config/logging.pp
+++ b/manifests/config/logging.pp
@@ -6,8 +6,6 @@ class dummy::config::logging {
   # FIXME: ensure your module's logging settings are defined here.
   $msg = "FIXME: define the ${module_name} module's logging settings."
 
-  notify{ 'FIXME: logging': message => $msg } # FIXME: remove this and add logic
+  notify { 'FIXME: logging': message => $msg } # FIXME: remove this and add logic
   err( $msg )                                 # FIXME: remove this and add logic
-
 }
-

--- a/manifests/config/pki.pp
+++ b/manifests/config/pki.pp
@@ -6,8 +6,6 @@ class dummy::config::pki {
   # FIXME: ensure your module's pki settings are defined here.
   $msg = "FIXME: define the ${module_name} module's pki settings."
 
-  notify{ 'FIXME: pki': message => $msg } # FIXME: remove this and add logic
+  notify { 'FIXME: pki': message => $msg } # FIXME: remove this and add logic
   err( $msg )                             # FIXME: remove this and add logic
-
 }
-

--- a/manifests/config/selinux.pp
+++ b/manifests/config/selinux.pp
@@ -6,7 +6,6 @@ class dummy::config::selinux {
   # FIXME: ensure your module's selinux settings are defined here.
   $msg = "FIXME: define the ${module_name} module's selinux settings."
 
-  notify{ 'FIXME: selinux': message => $msg } # FIXME: remove this and add logic
+  notify { 'FIXME: selinux': message => $msg } # FIXME: remove this and add logic
   err( $msg )                                 # FIXME: remove this and add logic
-
 }

--- a/manifests/config/tcpwrappers.pp
+++ b/manifests/config/tcpwrappers.pp
@@ -6,8 +6,6 @@ class dummy::config::tcpwrappers {
   # FIXME: ensure your module's tcpwrappers settings are defined here.
   $msg = "FIXME: define the ${module_name} module's tcpwrappers settings."
 
-  notify{ 'FIXME: tcpwrappers': message => $msg } # FIXME: remove this, add logic
+  notify { 'FIXME: tcpwrappers': message => $msg } # FIXME: remove this, add logic
   err( $msg )                                     # FIXME: remove this, add logic
-
 }
-

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,12 @@
 # @param package_name
 #   The name of the dummy package
 #
+# @param package_ensure
+#   The ensure status of the dummy package
+#
+# @param tcp_listen_port
+#   The TCP port on which the dummy service listens
+#
 # @param trusted_nets
 #   A whitelist of subnets (in CIDR notation) permitted access
 #
@@ -33,6 +39,9 @@
 # @param foo
 #   A new API thingamie
 #
+# @param bar
+#   Another new API thingamie
+#
 # @author SIMP
 #
 class dummy (
@@ -40,7 +49,7 @@ class dummy (
   String                             $package_name       = 'dummy',
   String[1]                          $package_ensure     = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
   Simplib::Port                      $tcp_listen_port    = 9999,
-  Simplib::Netlist                   $trusted_nets       = simplib::lookup('simp_options::trusted_nets', {'default_value' => ['127.0.0.1/32'] }),
+  Simplib::Netlist                   $trusted_nets       = simplib::lookup('simp_options::trusted_nets', { 'default_value' => ['127.0.0.1/32'] }),
   Variant[Boolean,Enum['simp']]      $pki         = simplib::lookup('simp_options::pki', { 'default_value'         => false }),
   Boolean                            $auditing    = simplib::lookup('simp_options::auditd', { 'default_value'      => false }),
   Variant[Boolean,Enum['firewalld']] $firewall    = simplib::lookup('simp_options::firewall', { 'default_value'    => false }),
@@ -50,50 +59,49 @@ class dummy (
   Boolean                            $foo         = true,
   Boolean                            $bar         = true,
 ) {
-
   simplib::assert_metadata($module_name)
 
   include 'dummy::install'
   include 'dummy::config'
   include 'dummy::service'
 
-  Class[ 'dummy::install' ]
-  -> Class[ 'dummy::config' ]
-  ~> Class[ 'dummy::service' ]
+  Class['dummy::install']
+  -> Class['dummy::config']
+  ~> Class['dummy::service']
 
   if $pki {
     include 'dummy::config::pki'
-    Class[ 'dummy::config::pki' ]
-    -> Class[ 'dummy::service' ]
+    Class['dummy::config::pki']
+    -> Class['dummy::service']
   }
 
   if $auditing {
     include 'dummy::config::auditing'
-    Class[ 'dummy::config::auditing' ]
-    -> Class[ 'dummy::service' ]
+    Class['dummy::config::auditing']
+    -> Class['dummy::service']
   }
 
   if $firewall {
     include 'dummy::config::firewall'
-    Class[ 'dummy::config::firewall' ]
-    -> Class[ 'dummy::service' ]
+    Class['dummy::config::firewall']
+    -> Class['dummy::service']
   }
 
   if $logging {
     include 'dummy::config::logging'
-    Class[ 'dummy::config::logging' ]
-    -> Class[ 'dummy::service' ]
+    Class['dummy::config::logging']
+    -> Class['dummy::service']
   }
 
   if $selinux {
     include 'dummy::config::selinux'
-    Class[ 'dummy::config::selinux' ]
-    -> Class[ 'dummy::service' ]
+    Class['dummy::config::selinux']
+    -> Class['dummy::service']
   }
 
   if $tcpwrappers {
     include 'dummy::config::tcpwrappers'
-    Class[ 'dummy::config::tcpwrappers' ]
-    -> Class[ 'dummy::service' ]
+    Class['dummy::config::tcpwrappers']
+    -> Class['dummy::service']
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 class dummy::install {
   assert_private()
 
-  package { $::dummy::package_name:
-    ensure => $::dummy::package_ensure
+  package { $dummy::package_name:
+    ensure => $dummy::package_ensure
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,7 @@
 class dummy::service {
   assert_private()
 
-  service { $::dummy::service_name:
+  service { $dummy::service_name:
     ensure     => running,
     enable     => true,
     hasstatus  => true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "simp-mockup",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "author": "SIMP",
   "summary": "A mockup Puppet module used to test SIMP CI, RELENG, and the SIMP puppet module skeleton",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-mockup",
   "project_page": "https://www.simp-project.com/",
-  "issues_url": "https://simp-project.atlassian.net/",
+  "issues_url": "https://github.com/simp/pupmod-simp-mockup/issues",
   "tags": [
     "simp",
     "mockup"
@@ -14,47 +14,58 @@
   "dependencies": [
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 6.0.1 < 7.0.0"
+      "version_requirement": ">= 6.5.3 < 9.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.15.0 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 7.0.0"
+      "version_requirement": ">= 4.9.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8"
+        "8",
+        "9",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
       ]
     }
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-mockup",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": "SIMP",
   "summary": "A mockup Puppet module used to test SIMP CI, RELENG, and the SIMP puppet module skeleton",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -89,16 +89,19 @@ describe 'dummy' do
     describe 'dummy class without any parameters on Solaris/Nexenta' do
       let(:facts) do
         {
-          osfamily: 'Solaris',
-          operatingsystem: 'Nexenta',
           os: {
             family: 'Solaris',
             name: 'Nexenta',
+            release: {
+              full: '1.0',
+              major: '1',
+            },
           },
         }
       end
+      let(:hieradata) { 'assert_metadata_failure' }
 
-      it { expect { is_expected.to contain_package('dummy') }.to raise_error(Puppet::Error, %r{'Nexenta' is not supported}) }
+      it { expect { is_expected.to contain_package('dummy') }.to raise_error(Puppet::Error, %r{'Nexenta 1\.0' is not supported}) }
     end
   end
 end

--- a/spec/fixtures/hieradata/assert_metadata_failure.yaml
+++ b/spec/fixtures/hieradata/assert_metadata_failure.yaml
@@ -1,0 +1,3 @@
+---
+simplib::assert_metadata::options:
+  fatal: true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,10 +28,6 @@ default_hiera_config = <<~HIERA_CONFIG
   ---
   version: 5
   hierarchy:
-    - name: SIMP Compliance Engine
-      lookup_key: compliance_markup::enforcement
-      options:
-        enabled_sce_versions: [2]
     - name: Custom Test Hiera
       path: "%{custom_hiera}.yaml"
     - name: "%{module_name}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 
-require 'puppetlabs_spec_helper/module_spec_helper'
+require 'voxpupuli/test/spec_helper'
 require 'rspec-puppet'
 require 'simp/rspec-puppet-facts'
 include Simp::RspecPuppetFacts


### PR DESCRIPTION
## Summary

Round 2 of the module refresh: migrate the test toolchain off the `puppet` gem onto the OpenVox stack, and add a Ruby 4.0 / OpenVox 9 preview to CI. Mirrors `rubygem-simp-rake-helpers` and `rubygem-simp-beaker-helpers`.

No `metadata.json` version bump or `CHANGELOG` entry: build/test-tooling changes with no end-user-visible effect.

## Changes

- **Gemfile**: `openvox` only (drop `puppet`); `puppet-strings` -> `openvox-strings` (removes the transitive `puppet` and `facter` gems); drop `pdk` and `puppetlabs_spec_helper`; let `voxpupuli-test` manage rubocop/-rake/-rspec; require `simp-rake-helpers ~> 6.0` and `simp-beaker-helpers ~> 3.1`
- **Rakefile**: `require 'openvox-strings/tasks'` (where applicable)
- **spec/spec_helper.rb**: `require 'voxpupuli/test/spec_helper'`
- **.fixtures.yml**: drop the self-referencing `"#{source_dir}"` symlink (puppet_fixtures auto-creates it and does not interpolate that token)
- **pr_tests.yml**: test OpenVox 8 on Ruby 3.2 and 3.4, plus a **Ruby 4.0 / OpenVox 9 preview**; build with `rake pupmod:build`
- **tag_deploy.yml**: build with `rake pupmod:build`; deploy Ruby -> `3.4.9` (openvox requires Ruby >= 3.1)
- **REFERENCE.md**: regenerated with `openvox-strings` (where it changed)

Verified locally: the resolved bundle contains no `puppet` or `facter` gem. The Ruby 4.0 preview passes in CI on the pilot module (pupmod-simp-at#114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)