### PR TITLE
[puppetsync] Pull RPM build containers from ghcr.io/simp/simp-<os>-build

### DIFF
--- a/.github/workflows/release_rpms.yml
+++ b/.github/workflows/release_rpms.yml
@@ -75,10 +75,10 @@ on:
         description: "Dry run (Test-build RPMs)"
         required: false
         default: 'no'
-      verbose:
-        description: 'Verbose RPM builds when "yes"'
-        required: false
-        default: 'no'
+      #verbose:
+      #  description: 'Verbose RPM builds when "yes"'
+      #  required: false
+      #  default: 'no'
       rebuild_number:
         description: 'If this is an RPM rebuild, put the number of the rebuild here'
         required: false


### PR DESCRIPTION
This patch updates release_rpms.yml to pull its build containers from
ghcr.io/simp/simp-<os>-build instead of the retired
docker.io/simpproject/simp_build_<os> images, and adds a
build_container_tag input (default `latest`) so a dated container tag
can be pinned when dispatching the workflow.