### PR TITLE
Add create_release_tag.yml calling the simp/gha-workflows reusable workflow

### DIFF
--- a/.github/workflows/create_release_tag.yml
+++ b/.github/workflows/create_release_tag.yml
@@ -1,0 +1,34 @@
+# Manual action to create + push a release tag from metadata.json & CHANGELOG
+# ------------------------------------------------------------------------------
+#
+#             NOTICE: **This file is maintained with puppetsync**
+#
+# This file is updated automatically as part of a puppet module baseline.
+#
+# The next baseline sync will overwrite any local changes to this file!
+#
+# ==============================================================================
+#
+# All logic lives in the reusable workflow in simp/gha-workflows; this file
+# only forwards the manual trigger. See simp/puppetsync#85.
+#
+---
+name: 'RELENG: Create release tag'
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (validate + report the tag annotation, don't push)"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  create-release-tag:
+    uses: simp/gha-workflows/.github/workflows/puppet_create_release_tag.yml@ac00f2ff0498d2e8234b5338e898505e33e939de  # v1.0.0 candidate
+    with:
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit
+    permissions:
+      contents: write


### PR DESCRIPTION
Pilot for simp/puppetsync#85 (reusable workflows), using the workflow converted from simp/puppetsync#43.

This shim only forwards the manual `workflow_dispatch` trigger; all tagging logic lives in [`simp/gha-workflows`](https://github.com/simp/gha-workflows/blob/main/.github/workflows/puppet_create_release_tag.yml). It's pinned to a commit SHA for the pilot; once this validates the calling contract end-to-end, `gha-workflows` gets tagged `v1.0.0` and the puppetsync rollout (rework of simp/puppetsync#43) switches the fleet to the tag.

Test plan after merge, exercising the untagged 0.6.0 in `metadata.json`:
1. Dispatch with `dry_run: true` — expect validations to pass and the 0.6.0 CHANGELOG annotation in the log, no tag pushed
2. Dispatch for real — tag `0.6.0` is pushed and `tag_deploy.yml` fires (which also re-exercises the reworked `release_rpms.yml` el8/el9/el10 path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)