### PR TITLE
Pin the create-release-tag reusable workflow to v1.0.0

### DIFF
--- a/.github/workflows/create_release_tag.yml
+++ b/.github/workflows/create_release_tag.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   create-release-tag:
-    uses: simp/gha-workflows/.github/workflows/puppet_create_release_tag.yml@ac00f2ff0498d2e8234b5338e898505e33e939de  # v1.0.0 candidate
+    uses: simp/gha-workflows/.github/workflows/puppet_create_release_tag.yml@v1.0.0
     with:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit


### PR DESCRIPTION
The pilot (#104) pinned the commit SHA before `simp/gha-workflows` had a release, with a `# v1.0.0 candidate` comment that Renovate's pin convention doesn't recognize — so the pin would sit unmanaged. `v1.0.0` points at that exact commit; this makes the file byte-identical to the puppetsync template and hands the pin to Renovate.

(The fleet sync intentionally didn't normalize this: `uses:` refs are Renovate-preserved values in the merge engine, so mockup came out `unchanged`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)