### PR TITLE
[puppetsync] Re-assert the refreshed pupmod baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,22 @@ dist
 /log
 /doc
 /Gemfile.lock
+/Gemfile.local
+
+## AI coding assistant-specific configuration
+## The standard is AGENTS.md
+# Claude Code
+/CLAUDE.md
+/.claude/
+# GitHub Copilot
+/.github/copilot-instructions.md
+# Cursor
+/.cursor/
+/.cursorrules
+# Windsurf
+/.windsurf/
+/.windsurfrules
+# Gemini CLI
+/GEMINI.md
+# Cline
+/.clinerules/

--- a/.pdkignore
+++ b/.pdkignore
@@ -55,3 +55,4 @@
 /spec/
 /.vscode/
 /tests/
+/AGENTS.md

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -13,4 +13,6 @@
 # This is here because the code can't handle lookups in parameters and SIMP
 # modules have a LOT of those
 --no-parameter_order-check
+# puppet-lint-strict_indent-check 5.0.0 crashes on some valid manifests
+# (remove when the plugin is fixed upstream)
 --no-strict_indent-check


### PR DESCRIPTION
This patch re-asserts the puppetsync-managed baseline files after
reconciling the templates with the deployed fleet (the templates
now describe the OpenVox-era reality — voxpupuli-test spec_helper,
current dotfiles):

- spec/spec_helper.rb: normalized to the fleet-majority variant
- .puppet-lint.rc: disable the strict_indent check fleet-wide
  (puppet-lint-strict_indent-check 5.0.0 crashes on some valid
  manifests; 16 repos already carried this workaround)
- .gitignore/.pdkignore/.gitattributes/.rspec: majority variants

Gemfiles and workflow files are bootstrap-strategy and are not
touched by this sync (Renovate manages their versions in place).